### PR TITLE
Egui version boost

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["gui"]
 keywords = ["egui", "toast", "notification"]
 
 [dependencies]
-egui = "0.19.0"
+egui = "0.20.1"
 
 [dev-dependencies]
-eframe = { version = "0.19.0", features = ["dark-light"] }
+eframe = { version = "0.20.1", features = ["dark-light"] }


### PR DESCRIPTION
Boosted `egui` version to `0.20.1`.

Demo works fine. 

We use `egui-toast` in our project, but wanted to use the latest `egui` version. Currently, we download the dependency from GitHub branch, but it would be nice to have the version updated on official repo.