### PR TITLE
Disable default features for egui

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ keywords = ["egui", "toast", "notification"]
 members = ["demo"]
 
 [dependencies]
-egui = "0.22.0"
+egui = { version = "0.22.0", default-features = false }
 
 [profile.release]
 opt-level = 2


### PR DESCRIPTION
By default, egui includes several default fonts during build which may cause font licensing issues for user of egui-toast. As it happens, that is also the only default feature of egui.

The toast notifications work regardless of the font used, so introducing these default fonts through the crate is unnecessary. We can disable them by disabling default features for egui.