### PR TITLE
make egui-toast "threading-friendly" (adding new toast does not require Toasts instance)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "egui-toast"
 description = "Toast notifications for the egui library"
-version = "0.8.1"
+version = "0.9.0"
 authors = ["Urho Laukkarinen <urho.laukkarinen@gmail.com>"]
 edition = "2021"
 
@@ -17,6 +17,8 @@ members = ["demo"]
 
 [dependencies]
 egui = { version = "0.22.0", default-features = false }
+lazy_static = "1.4.0"
+crossbeam-channel = "0.5.8"
 
 [profile.release]
 opt-level = 2

--- a/README.md
+++ b/README.md
@@ -18,24 +18,22 @@ cargo run -p egui-toast-demo
 cd demo && trunk serve
 ```
 
-
 ```rust
-let mut toasts = Toasts::new()
-    .anchor(Align2::RIGHT_BOTTOM, (-10.0, -10.0)) // 10 units from the bottom right corner
-    .direction(egui::Direction::BottomUp);
-
 if ui.button("Add toast").clicked() {
-    toasts.add(Toast {
+    Toast {
         text: "Hello, World!".into(),
-        kind: ToastKind::Error,
+        kind: ToastKind::Warning,
         options: ToastOptions::default()
             .duration_in_seconds(5.0)
             .show_progress(true)
-    });
-}
+    }.push();
 
-// Show and update all toasts
-toasts.show(ctx);
+}
+Toasts::new()
+    .anchor(Align2::RIGHT_BOTTOM, (-10.0, -10.0)) // 10 units from the bottom right corner
+    .direction(egui::Direction::BottomUp)
+    // Show and update all toasts
+    toasts.show(ctx);
 ```
 
 ## Customization
@@ -59,16 +57,15 @@ fn my_custom_toast_contents(ui: &mut Ui, toast: &mut Toast) -> Response {
         }).response
 }
 
-let mut toasts = Toasts::new()
-    .custom_contents(MY_CUSTOM_TOAST, my_custom_toast_contents);
-
 if ui.button("Add toast").clicked() {
-    toasts.add(Toast {
+    Toast {
         text: "Hello, World!".into(),
         kind: ToastKind::Custom(MY_CUSTOM_TOAST),
         options: ToastOptions::default()
-    });
+    }.push();
 }
 
-toasts.show(ctx);
+Toasts::new()
+    .custom_contents(MY_CUSTOM_TOAST, my_custom_toast_contents)
+    .show(ctx);
 ```

--- a/README.md
+++ b/README.md
@@ -20,13 +20,23 @@ cd demo && trunk serve
 
 ```rust
 if ui.button("Add toast").clicked() {
-    Toast {
-        text: "Hello, World!".into(),
-        kind: ToastKind::Warning,
-        options: ToastOptions::default()
-            .duration_in_seconds(5.0)
-            .show_progress(true)
-    }.push();
+    Toast::warning("Hello, World!");
+    //OR equivalently:
+    // Toast::create( 
+    //     "Hello, World!",
+    //     ToastKind::Warning,
+    //     ToastOptions::default()
+    //         .duration_in_seconds(5.0)
+    //         .show_progress(true)
+    // );
+    //OR equivalently:
+    // Toast {
+    //     text: "Hello, World!".into(),
+    //     kind: ToastKind::Warning,
+    //     options: ToastOptions::default()
+    //         .duration_in_seconds(5.0)
+    //         .show_progress(true)
+    // }.push();
 
 }
 Toasts::new()

--- a/demo/Cargo.toml
+++ b/demo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egui-toast-demo"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 
 [dependencies]

--- a/demo/src/main.rs
+++ b/demo/src/main.rs
@@ -68,22 +68,21 @@ impl Default for Demo {
 
 impl eframe::App for Demo {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        // Show the options window
+        self.options_window(ctx);
+
         // Recreate the toasts in case the demo options have changed.
-        let mut toasts = Toasts::new()
+        Toasts::new()
             .anchor(self.alignment, self.offset)
             .direction(self.direction)
-            .custom_contents(MY_CUSTOM_TOAST, my_custom_toast_contents);
-
-        // Show the options window
-        self.options_window(ctx, &mut toasts);
-
-        // Draw and update the toasts
-        toasts.show(ctx);
+            .custom_contents(MY_CUSTOM_TOAST, my_custom_toast_contents)
+            // Draw and update the toasts
+            .show(ctx);
     }
 }
 
 impl Demo {
-    fn options_window(&mut self, ctx: &egui::Context, toasts: &mut Toasts) {
+    fn options_window(&mut self, ctx: &egui::Context) {
         let Self {
             i,
             offset: position,
@@ -170,21 +169,23 @@ impl Demo {
                     .duration(duration);
 
                 if ui.button("Give me a toast").clicked() {
-                    toasts.add(Toast {
+                    Toast {
                         kind: *kind,
                         text: format!("Hello, I am a toast {}", i).into(),
                         options,
-                    });
+                    }
+                    .push();
 
                     *i += 1;
                 }
 
                 if ui.button("Give me a custom toast").clicked() {
-                    toasts.add(Toast {
+                    Toast {
                         text: format!("Hello, I am a custom toast {}", i).into(),
                         kind: ToastKind::Custom(MY_CUSTOM_TOAST),
                         options,
-                    });
+                    }
+                    .push();
 
                     *i += 1;
                 }

--- a/demo/src/main.rs
+++ b/demo/src/main.rs
@@ -11,6 +11,10 @@ const MY_CUSTOM_TOAST: u32 = 0;
 
 #[cfg(not(target_arch = "wasm32"))]
 fn main() -> eframe::Result<()> {
+    //Toast can be created anywhere, but it will not be showed until `Toasts::show` call
+    //Below creates simple info toast with default for info toast options (it will be shown for 2 seconds, with progressbar and info-icon)
+    Toast::info("Simple toast; App has started");
+    
     eframe::run_native(
         "egui-toast demo",
         eframe::NativeOptions::default(),

--- a/demo/src/main.rs
+++ b/demo/src/main.rs
@@ -4,17 +4,27 @@ use eframe::egui;
 use egui::style::Margin;
 use egui::{Align2, Color32, Direction, Frame, Pos2, RichText, Widget};
 
-use egui_toast::{Toast, ToastKind, ToastOptions, Toasts};
+use egui_toast::{Toast, ToastKind, ToastOptions, ToastTrait, Toasts};
 
 /// Identifier for a custom toast kind
 const MY_CUSTOM_TOAST: u32 = 0;
+
+//You can define your own Toast types with different default ToastOptions
+//MyToast (contrary to Toast) will display error toast for finite time (10 sec.)
+struct MyToast();
+impl ToastTrait for MyToast {
+    const ERROR: ToastOptions = ToastOptions::new(true, true, 10.0);
+}
 
 #[cfg(not(target_arch = "wasm32"))]
 fn main() -> eframe::Result<()> {
     //Toast can be created anywhere, but it will not be showed until `Toasts::show` call
     //Below creates simple info toast with default for info toast options (it will be shown for 2 seconds, with progressbar and info-icon)
     Toast::info("Simple toast; App has started");
-    
+
+    MyToast::error("MyToast error will soon disappear");
+    Toast::error("Toast error will stay until discarded");
+
     eframe::run_native(
         "egui-toast demo",
         eframe::NativeOptions::default(),

--- a/demo/src/main.rs
+++ b/demo/src/main.rs
@@ -14,6 +14,8 @@ const MY_CUSTOM_TOAST: u32 = 0;
 struct MyToast();
 impl ToastTrait for MyToast {
     const ERROR: ToastOptions = ToastOptions::new(true, true, 10.0);
+    const CUSTOM: &'static [(u32, ToastOptions)] =
+        &[(MY_CUSTOM_TOAST, ToastOptions::new(true, true, 3.0))];
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -24,6 +26,12 @@ fn main() -> eframe::Result<()> {
 
     MyToast::error("MyToast error will soon disappear");
     Toast::error("Toast error will stay until discarded");
+
+    MyToast::custom(MY_CUSTOM_TOAST, "MyToast custom stays for 3s");
+    Toast::custom(
+        MY_CUSTOM_TOAST,
+        "Toast custom stays for 5s, same as warning",
+    );
 
     eframe::run_native(
         "egui-toast demo",

--- a/src/toast.rs
+++ b/src/toast.rs
@@ -1,5 +1,15 @@
+use crossbeam_channel::{Receiver, Sender};
 use egui::WidgetText;
+use lazy_static::lazy_static;
 use std::time::Duration;
+
+lazy_static! {
+    /// Toasts added since the last draw call. These are moved to the
+    /// egui context's memory, so you are free to recreate the [`Toasts`] instance every frame.
+    pub(crate) static ref TOASTS_CHANNEL: (Sender<Toast>, Receiver<Toast>) = {
+        crossbeam_channel::unbounded()
+    };
+}
 
 #[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
 pub enum ToastKind {
@@ -27,6 +37,10 @@ impl Toast {
     /// Close the toast immediately
     pub fn close(&mut self) {
         self.options.ttl_sec = 0.0;
+    }
+    /// Push this toast to global toasts queue to show it.
+    pub fn push(self) {
+        let _ = TOASTS_CHANNEL.0.send(self);
     }
 }
 

--- a/src/toast.rs
+++ b/src/toast.rs
@@ -53,41 +53,78 @@ impl Toast {
     }
     /// Create default error toast
     pub fn error(text: impl Into<WidgetText>) {
-        Toast::create(
-            ToastKind::Error,
-            text,
-            ToastOptions::default().show_progress(false),
-        )
+        <Toast as ToastTrait>::error(text) // repeated function from trait, so it will work even if trai is not in scope
     }
     /// Create default warning toast
     pub fn warning(text: impl Into<WidgetText>) {
-        Toast::create(
-            ToastKind::Warning,
-            text,
-            ToastOptions::default()
-                .duration_in_seconds(5.0)
-                .show_progress(true),
-        )
+        <Toast as ToastTrait>::warning(text)
     }
     /// Create default success toast
     pub fn success(text: impl Into<WidgetText>) {
-        Toast::create(
-            ToastKind::Success,
-            text,
-            ToastOptions::default()
-                .duration_in_seconds(2.0)
-                .show_progress(true),
-        )
+        <Toast as ToastTrait>::success(text)
     }
     /// Create default info toast
     pub fn info(text: impl Into<WidgetText>) {
-        Toast::create(
-            ToastKind::Info,
-            text,
-            ToastOptions::default()
-                .duration_in_seconds(2.0)
-                .show_progress(true),
-        )
+        <Toast as ToastTrait>::info(text)
+    }
+}
+impl ToastTrait for Toast {}
+
+///`ToastTrait` allows to define own toast classes with different (from `Toast`) `ToastOptions`
+/// Only associated constants are to be modified.
+/// E.g. constant WARNING represents `ToastOptions` for warning toast.
+/// Example:
+/// ```
+/// //MyToast (contrary to Toast) will display error toast for finite time (10 sec.)
+/// struct MyToast();
+/// impl ToastTrait for MyToast {
+///     const ERROR: ToastOptions = ToastOptions::new(true, true, 10.0);
+/// }
+/// ...
+/// MyToast::error("MyToast error will soon disappear");
+/// Toast::error("Toast error will stay until discarded");
+/// ```
+pub trait ToastTrait {
+    //default values, are values used for Toast
+    const WARNING: ToastOptions = ToastOptions {
+        show_icon: true,
+        show_progress: true,
+        ttl_sec: 5.0,
+        initial_ttl_sec: 5.0,
+    };
+    const ERROR: ToastOptions = ToastOptions {
+        show_icon: true,
+        show_progress: false,
+        ttl_sec: f64::INFINITY,
+        initial_ttl_sec: f64::INFINITY,
+    };
+    const INFO: ToastOptions = ToastOptions {
+        show_icon: true,
+        show_progress: true,
+        ttl_sec: 2.0,
+        initial_ttl_sec: 2.0,
+    };
+    const SUCCESS: ToastOptions = ToastOptions {
+        show_icon: true,
+        show_progress: true,
+        ttl_sec: 2.0,
+        initial_ttl_sec: 2.0,
+    };
+    /// Create default error toast
+    fn error(text: impl Into<WidgetText>) {
+        Toast::create(ToastKind::Error, text, Self::ERROR)
+    }
+    /// Create default warning toast
+    fn warning(text: impl Into<WidgetText>) {
+        Toast::create(ToastKind::Warning, text, Self::WARNING)
+    }
+    /// Create default success toast
+    fn success(text: impl Into<WidgetText>) {
+        Toast::create(ToastKind::Success, text, Self::SUCCESS)
+    }
+    /// Create default info toast
+    fn info(text: impl Into<WidgetText>) {
+        Toast::create(ToastKind::Info, text, Self::INFO)
     }
 }
 
@@ -115,6 +152,15 @@ impl Default for ToastOptions {
 }
 
 impl ToastOptions {
+    pub const fn new(show_icon: bool, show_progress: bool, time_sec: f64) -> Self {
+        Self {
+            show_icon,
+            show_progress,
+            ttl_sec: time_sec,
+            initial_ttl_sec: time_sec,
+        }
+    }
+
     /// Set duration of the toast. [None] duration means the toast never expires.
     pub fn duration(mut self, duration: impl Into<Option<Duration>>) -> Self {
         self.ttl_sec = duration

--- a/src/toast.rs
+++ b/src/toast.rs
@@ -51,21 +51,25 @@ impl Toast {
         }
         .push()
     }
-    /// Create default error toast
+    /// Create default error toast (show icon, show until canceled)
     pub fn error(text: impl Into<WidgetText>) {
         <Toast as ToastTrait>::error(text) // repeated function from trait, so it will work even if trai is not in scope
     }
-    /// Create default warning toast
+    /// Create default warning toast (show icon & progressbar, show for 5s)
     pub fn warning(text: impl Into<WidgetText>) {
         <Toast as ToastTrait>::warning(text)
     }
-    /// Create default success toast
+    /// Create default success toast (show icon & progressbar, show for 2s)
     pub fn success(text: impl Into<WidgetText>) {
         <Toast as ToastTrait>::success(text)
     }
-    /// Create default info toast
+    /// Create default info toast (show icon & progressbar, show for 2s)
     pub fn info(text: impl Into<WidgetText>) {
         <Toast as ToastTrait>::info(text)
+    }
+    /// Create default custom toast (same ToastOptions as warning)
+    pub fn custom(type_id: u32, text: impl Into<WidgetText>) {
+        <Toast as ToastTrait>::custom(type_id, text)
     }
 }
 impl ToastTrait for Toast {}
@@ -110,6 +114,10 @@ pub trait ToastTrait {
         ttl_sec: 2.0,
         initial_ttl_sec: 2.0,
     };
+    /// `CUSTOM` is colection of (toast_type_id, toast_options) that alows to set diffrent ToastOptions for each custom toast type
+    /// If `CUSTOM` does not contain entry for some toast_type_id, WARNING ToastOptions will be used.
+    const CUSTOM: &'static [(u32, ToastOptions)] = &[];
+
     /// Create default error toast
     fn error(text: impl Into<WidgetText>) {
         Toast::create(ToastKind::Error, text, Self::ERROR)
@@ -125,6 +133,17 @@ pub trait ToastTrait {
     /// Create default info toast
     fn info(text: impl Into<WidgetText>) {
         Toast::create(ToastKind::Info, text, Self::INFO)
+    }
+    /// Create default custom toast
+    fn custom(type_id: u32, text: impl Into<WidgetText>) {
+        Toast::create(
+            ToastKind::Custom(type_id),
+            text,
+            Self::CUSTOM
+                .iter()
+                .find(|(id, _)| *id == type_id)
+                .map_or(Self::WARNING, |(_, options)| options.clone()),
+        )
     }
 }
 

--- a/src/toast.rs
+++ b/src/toast.rs
@@ -42,6 +42,53 @@ impl Toast {
     pub fn push(self) {
         let _ = TOASTS_CHANNEL.0.send(self);
     }
+    /// Wrapper around `Toast{...}.push()`
+    pub fn create(kind: ToastKind, text: impl Into<WidgetText>, options: ToastOptions) {
+        Toast {
+            kind: kind,
+            text: text.into(),
+            options: options,
+        }
+        .push()
+    }
+    /// Create default error toast
+    pub fn error(text: impl Into<WidgetText>) {
+        Toast::create(
+            ToastKind::Error,
+            text,
+            ToastOptions::default().show_progress(false),
+        )
+    }
+    /// Create default warning toast
+    pub fn warning(text: impl Into<WidgetText>) {
+        Toast::create(
+            ToastKind::Warning,
+            text,
+            ToastOptions::default()
+                .duration_in_seconds(5.0)
+                .show_progress(true),
+        )
+    }
+    /// Create default success toast
+    pub fn success(text: impl Into<WidgetText>) {
+        Toast::create(
+            ToastKind::Success,
+            text,
+            ToastOptions::default()
+                .duration_in_seconds(2.0)
+                .show_progress(true),
+        )
+    }
+    /// Create default info toast
+    pub fn info(text: impl Into<WidgetText>) {
+        Toast::create(
+            ToastKind::Info,
+            text,
+            ToastOptions::default()
+                .duration_in_seconds(2.0)
+                .show_progress(true),
+        )
+    }
 }
 
 #[derive(Copy, Clone)]


### PR DESCRIPTION
- replaced vector `Toasts.added_toasts` with global crossbeam_channel `TOASTS_CHANNEL`
- adding new toast does not require `Toasts` instance. Can be done directly from `Toast` (this allows pushing new toasts from any place in code including other threads and async functions)
-  ! `Toasts::add()` is marked depreciated (internaly it's now `toast.push()` )
-  ! `Toasts` is marked `#[must_use]` to enforce using `.show()` function
- added some convenience functions to `Toast`
- added `ToastTrait` to use convenience functions with user defined options
- version bumped to 0.9.0

Now there are 3 ways to add new toast (4 if counting depreciated `Toasts::add()`):

```Rust
//1.
Toast::warning("Hello, World!"); // OR Toast::error, Toast::info, Toast::success
 
//2.
Toast::create( 
    "Hello, World!",
    ToastKind::Warning,
    ToastOptions::default()
        .duration_in_seconds(5.0)
        .show_progress(true)
);

//3.
Toast {
    text: "Hello, World!".into(),
    kind: ToastKind::Warning,
    options: ToastOptions::default()
        .duration_in_seconds(5.0)
        .show_progress(true)
}.push();
```