### PR TITLE
Upgrade to egui v0.23

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ keywords = ["egui", "toast", "notification"]
 members = ["demo"]
 
 [dependencies]
-egui = { version = "0.22.0", default-features = false }
+egui = { version = "0.23.0", default-features = false }
 
 [profile.release]
 opt-level = 2

--- a/demo/Cargo.toml
+++ b/demo/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.8.0"
 edition = "2021"
 
 [dependencies]
-eframe = "0.22.0"
+eframe = "0.23.0"
 egui-toast = { path = ".." }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -265,12 +265,11 @@ fn default_toast_contents(ui: &mut Ui, toast: &mut Toast) -> Response {
     }
 
     // Draw the frame's stroke last
-    let frame_shape = Shape::Rect(RectShape {
-        rect: response.rect,
-        rounding: frame.rounding,
-        fill: Color32::TRANSPARENT,
-        stroke: ui.visuals().window_stroke,
-    });
+    let frame_shape = Shape::Rect(RectShape::stroke(
+        response.rect,
+        frame.rounding,
+        ui.visuals().window_stroke,
+    ));
     ui.painter().add(frame_shape);
 
     response


### PR DESCRIPTION
Egui just released a new version 0.23. This PR updates the dependency of both egui and eframe. I tested the demo seems to work fine without any other changes. The only change required is on the `RectShape` having additional fields, I opted to use the `RectShape::stroke` function instead to make the code a bit simpler too.

It would be great to have a new release of egui-toast after this PR, but I did not think this PR would be the right place for such a version bump.
