### PR TITLE
Added Send+ Sync to egui Toasts context

### DIFF
--- a/demo/src/main.rs
+++ b/demo/src/main.rs
@@ -1,3 +1,4 @@
+use std::sync::Arc;
 use std::time::Duration;
 
 use eframe::egui;
@@ -72,7 +73,7 @@ impl eframe::App for Demo {
         let mut toasts = Toasts::new()
             .anchor(self.alignment, self.offset)
             .direction(self.direction)
-            .custom_contents(MY_CUSTOM_TOAST, my_custom_toast_contents);
+            .custom_contents(MY_CUSTOM_TOAST, Arc::new(my_custom_toast_contents));
 
         // Show the options window
         self.options_window(ctx, &mut toasts);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,7 @@ mod toast;
 pub use toast::*;
 
 use std::collections::HashMap;
+use std::sync::Arc;
 use std::time::Duration;
 
 use egui::epaint::RectShape;
@@ -82,7 +83,7 @@ pub const WARNING_COLOR: Color32 = Color32::from_rgb(255, 212, 0);
 pub const ERROR_COLOR: Color32 = Color32::from_rgb(255, 32, 0);
 pub const SUCCESS_COLOR: Color32 = Color32::from_rgb(0, 255, 32);
 
-pub type ToastContents = dyn Fn(&mut Ui, &mut Toast) -> Response;
+pub type ToastContents = Arc<dyn Fn(&mut Ui, &mut Toast) -> Response>;
 
 pub struct Toasts {
     id: Id,
@@ -142,7 +143,7 @@ impl Toasts {
     pub fn custom_contents(
         mut self,
         kind: impl Into<ToastKind>,
-        add_contents: impl Fn(&mut Ui, &mut Toast) -> Response + 'static,
+        add_contents: Arc<impl Fn(&mut Ui, &mut Toast) -> Response + 'static>,
     ) -> Self {
         self.custom_toast_contents
             .insert(kind.into(), Box::new(add_contents));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,7 @@ pub const WARNING_COLOR: Color32 = Color32::from_rgb(255, 212, 0);
 pub const ERROR_COLOR: Color32 = Color32::from_rgb(255, 32, 0);
 pub const SUCCESS_COLOR: Color32 = Color32::from_rgb(0, 255, 32);
 
-pub type ToastContents = Arc<dyn Fn(&mut Ui, &mut Toast) -> Response>;
+pub type ToastContents = Arc<dyn Fn(&mut Ui, &mut Toast) -> Response + Send + Sync>;
 
 pub struct Toasts {
     id: Id,
@@ -143,7 +143,7 @@ impl Toasts {
     pub fn custom_contents(
         mut self,
         kind: impl Into<ToastKind>,
-        add_contents: Arc<impl Fn(&mut Ui, &mut Toast) -> Response + 'static>,
+        add_contents: Arc<impl Fn(&mut Ui, &mut Toast) -> Response + Send + Sync + 'static>,
     ) -> Self {
         self.custom_toast_contents
             .insert(kind.into(), Box::new(add_contents));


### PR DESCRIPTION
Wrapped the function callback in Arc<> and specified Send+ Sync on the dyn Fn input. This PR Allows for the usage of Toasts in something such as Bevy ECS like so:

```rs
use bevy::prelude::*;

#[derive(Resource)]
pub struct Toasts(egui_toast::Toasts);
```

