### PR TITLE
update egui to 0.24.1, remove optlevel=2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "egui-toast"
 description = "Toast notifications for the egui library"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["Urho Laukkarinen <urho.laukkarinen@gmail.com>"]
 edition = "2021"
 
@@ -16,7 +16,4 @@ keywords = ["egui", "toast", "notification"]
 members = ["demo"]
 
 [dependencies]
-egui = { version = "0.24.0", default-features = false }
-
-[profile.release]
-opt-level = 2
+egui = { version = "0.24.1", default-features = false }


### PR DESCRIPTION
* Updates egui to 0.24.1
* Removes optlevel=2 in Cargo.toml, since this should be decided by the user of the library