### PR TITLE
⬆️ Update `egui` to `v0.25`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,4 @@ keywords = ["egui", "toast", "notification"]
 members = ["demo"]
 
 [dependencies]
-egui = { version = "0.24.1", default-features = false }
+egui = { version = "0.25", default-features = false }

--- a/demo/Cargo.toml
+++ b/demo/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.8.0"
 edition = "2021"
 
 [dependencies]
-eframe = "0.24.0"
+eframe = "0.25.0"
 egui-toast = { path = ".." }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]


### PR DESCRIPTION
`Egui` released a new version `0.25`, this PR updates the `Cargo.toml` files.

Additionally I opted to go for `0.25` instead of `0.25.0`, such that dependent projects might do a minor version bump without requiring this to be version bumped as well.