### PR TITLE
Add `license = "MIT"` to `Cargo.toml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ version = "0.12.0"
 authors = ["Urho Laukkarinen <urho.laukkarinen@gmail.com>"]
 edition = "2021"
 
+license = "MIT"
 license-file = "LICENSE"
 readme = "README.md"
 homepage = "https://github.com/urholaukkarinen/egui-toast"


### PR DESCRIPTION
This PR adds a `license = "MIT"` field to `Cargo.toml`. 

This does not change the license of `egui-toast` - it is still the MIT license. However, this allows tools (such as `crates.io` or [`cargo-license`](https://crates.io/crates/cargo-license)) to better recognize the license used by this crate.

For example, currently `crates.io` cites this crate has having a non-standard license, as only `license-file` is specified and `crates.io` cannot detect if the file is indeed the MIT license. With this change, `crates.io` can (upon the next published update) detect that the license is indeed the MIT license.

----

P.S. The `license-file` has been left in, because this ensures the `LICENSE` file will be included in the crate with `cargo package`.

To be clear, even without the `license-file` field, `LICENSE` will always be included, unless excluded with the `exclude` field, or if the `include` field existed and did not specify `"LICENSE"`.

However, I have opted to leave it in because this ensures `license-file` will always be distributed, even if the `include` field is specified.