### PR TITLE
Add support for multiple Toast instances with custom IDs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,6 +108,17 @@ impl Toasts {
         Self::default()
     }
 
+    /// Create a new [`Toasts`] instance with a custom id
+    ///
+    /// This can be useful if you want to have multiple toast groups
+    /// in the same UI.
+    pub fn with_id(id: Id) -> Self {
+        Self {
+            id,
+            ..Default::default()
+        }
+    }
+
     /// Position where the toasts show up.
     ///
     /// The toasts will start from this position and stack up


### PR DESCRIPTION
This PR introduces the ability to create multiple Toasts instances with custom IDs in the egui-toasts library. A new method with_id(id: Id) has been added to the Toasts struct, allowing developers to initialize toast groups with specific identifiers.
Key changes:

- Added with_id(id: Id) -> Self method to the Toasts implementation.
- This allows users to manage multiple independent toast groups within the same UI.

This change is useful for situations where toasts need to be categorized or grouped separately.